### PR TITLE
add execute permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ```sh
 $ mkdir -p ~/.packer.d/plugins
 $ wget https://github.com/inokappa/packer-post-processor-aws-parameter-store/releases/download/v0.0.3/packer-post-processor-aws-parameter-store_darwin_amd64 -O ~/.packer.d/plugins/packer-post-processor-aws-parameter-store
+$ chmod +x ~/.packer.d/plugins/packer-post-processor-aws-parameter-store
 ```
 
 ## Usage


### PR DESCRIPTION
It dose not have execution permission, the following error will occur.

```
Failed to initialize build 'amazon-ebs': error initializing post-processor 'aws-parameter-store': fork/exec /usr/local/bin/packer-post-processor-aws-parameter-store: no such file or directory
```